### PR TITLE
Session token not init

### DIFF
--- a/src/DevSpector.UI/App.axaml.cs
+++ b/src/DevSpector.UI/App.axaml.cs
@@ -77,7 +77,7 @@ namespace DevSpector.Desktop.UI
         {
             _kernel.Bind<IAuthorizationManager>().To<AuthorizationManager>().
                 WithConstructorArgument("builder", _hostBuilder);
-            _kernel.Bind<IUserSession>().To<UserSession>();
+            _kernel.Bind<IUserSession>().To<UserSession>().InSingletonScope();
         }
 
         private void AddSDK()

--- a/src/DevSpector.UI/ViewModels/UsersSection/Implementations/UserInfoViewModel.cs
+++ b/src/DevSpector.UI/ViewModels/UsersSection/Implementations/UserInfoViewModel.cs
@@ -15,7 +15,7 @@ namespace DevSpector.Desktop.UI.ViewModels
 
         public string AccessToken
         {
-            get { return _accessToken == null ? "N/A" : _accessToken; }
+            get { return _accessToken == null ? "" : _accessToken; }
             set => this.RaiseAndSetIfChanged(ref _accessToken, value);
         }
 


### PR DESCRIPTION
Because of ```IUserSession``` service was registered in transient mode, all user authorization data was lost when ```IUserSession``` moved to another view models. Now it's fixed