### PR TITLE
Host configuration

### DIFF
--- a/src/DevSpector.UI/App.axaml.cs
+++ b/src/DevSpector.UI/App.axaml.cs
@@ -97,7 +97,7 @@ namespace DevSpector.Desktop.UI
                     Environment.GetEnvironmentVariable("DEVSPECTOR_PORT"),
                     out port
                 );
-                if (port < 0) port = 0;
+                if (port <= 0) port = 80;
             }
 
             _hostBuilder = new HostBuilder(host, port, scheme);

--- a/src/DevSpector.UI/App.axaml.cs
+++ b/src/DevSpector.UI/App.axaml.cs
@@ -1,6 +1,4 @@
 using System;
-using System.Threading.Tasks;
-using MessageBox.Avalonia;
 using System.Collections.Generic;
 using Ninject;
 using Avalonia;

--- a/src/DevSpector.UI/App.axaml.cs
+++ b/src/DevSpector.UI/App.axaml.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Threading.Tasks;
+using MessageBox.Avalonia;
 using System.Collections.Generic;
 using Ninject;
 using Avalonia;
@@ -73,14 +75,34 @@ namespace DevSpector.Desktop.UI
 
         private void ConfigureTargetHost()
         {
-            var environment = Environment.GetEnvironmentVariable("DEVSPECTOR_ENV");
+            string environment = Environment.GetEnvironmentVariable("DEVSPECTOR_ENV");
 
-            if (environment == "Production")
-                _hostBuilder = new HostBuilder("devspector.herokuapp.com", scheme: "https");
-            else if (environment == "Development")
-                _hostBuilder = new HostBuilder("dev-devspector.herokuapp.com", scheme: "https");
+            string host = Environment.GetEnvironmentVariable("DEVSPECTOR_HOST");
+            string scheme = "http";
+            int port;
+
+            if (environment == "Development")
+            {
+                host = "dev-devspector.herokuapp.com";
+                scheme = "https";
+                port = 443;
+            }
             else
-                _hostBuilder = new HostBuilder(port: 5000);
+            {
+                host = Environment.GetEnvironmentVariable("DEVSPECTOR_HOST");
+                if (host == null)
+                    throw new InvalidOperationException("Задайте имя хоста через переменную \"DEVSPECTOR_HOST\"");
+
+                scheme = "http";
+
+                int.TryParse(
+                    Environment.GetEnvironmentVariable("DEVSPECTOR_PORT"),
+                    out port
+                );
+                if (port < 0) port = 0;
+            }
+
+            _hostBuilder = new HostBuilder(host, port, scheme);
         }
 
         private void SetupMainWindow()

--- a/src/DevSpector.UI/DevSpector.UI.csproj
+++ b/src/DevSpector.UI/DevSpector.UI.csproj
@@ -19,6 +19,7 @@
     <PackageReference Include="Deadpikle.AvaloniaProgressRing" Version="0.9.4" />
     <PackageReference Include="Live.Avalonia" Version="1.3.1" />
     <PackageReference Include="Material.Avalonia" Version="2.5.0.73-nightly" />
+    <PackageReference Include="MessageBox.Avalonia" Version="2.0.0" />
     <PackageReference Include="ninject" Version="3.3.4" />
   </ItemGroup>
   <ItemGroup>

--- a/src/DevSpector.UI/Program.cs
+++ b/src/DevSpector.UI/Program.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.IO;
 using Avalonia;
 using Avalonia.ReactiveUI;
 
@@ -9,8 +10,15 @@ namespace DevSpector.Desktop.UI
 		[STAThread]
 		public static void Main(string[] args)
 		{
-			BuildAvaloniaApp().
-				StartWithClassicDesktopLifetime(args);
+			try
+			{
+				BuildAvaloniaApp().
+					StartWithClassicDesktopLifetime(args);
+			}
+			catch (Exception e)
+			{
+				Log(e.Message);
+			}
 		}
 
 		public static AppBuilder BuildAvaloniaApp() =>
@@ -18,5 +26,20 @@ namespace DevSpector.Desktop.UI
 				UsePlatformDetect().
 				LogToTrace().
 				UseReactiveUI();
+
+		/// <summary>
+		/// Logs message into <c>logs/<cur-date>.txt</c> file into root of the app
+		/// </summary>
+		private static void Log(string message)
+		{
+			DateTime now = DateTime.Now;
+			var logsDir = "logs";
+			Directory.CreateDirectory(logsDir);
+			var targetPath = Path.Combine(logsDir, now.ToString("dd-MM-yyyy") + ".txt");
+			File.AppendAllText(
+				targetPath,
+				$"[{now.ToString("HH:MM:ss")}]\n{message}\n\n"
+			);
+		}
 	}
 }


### PR DESCRIPTION
# Now it's possible to configure host to connect to
 - It can be done by ```DEVSPECTOR_HOST``` environment variable that defines to which host application should connect. Port also can be set via ```DEVSPECTOR_PORT``` variable.
To make application connect to host specified in variable above ```DEVSPECTOR_ENV``` should be set to ```Production```. Otherwise, application will connect to test host ```dev-devspector.herokuapp.com``` using port ```443```.

- Critical errors are now logged to the root of the application folder in the ```logs``` folder. Each report locates in ```<cur-date>.txt``` file.